### PR TITLE
Fix missing auth env vars

### DIFF
--- a/src/cmd/set_description.go
+++ b/src/cmd/set_description.go
@@ -42,8 +42,8 @@ var setDescriptionCmd = &cobra.Command{
 
 		req.Header.Set("Content-Type", "application/json")
 
-		if len(viper.Get("user").(string)) == 0 || len(viper.Get("pass").(string)) == 0 {
-			log.Fatal("This command requires Docker Hub credentials to be set in your environment.")
+		if viper.Get("user") == nil || viper.Get("pass") == nil || len(viper.Get("user").(string)) == 0 || len(viper.Get("pass").(string)) == 0 {
+			log.Fatal("This command requires Docker Hub credentials (DOCKER_USER and DOCKER_PASS), credentials to be set in your environment.")
 		}
 
 		resp, err := sendRequest(req, viper.Get("user").(string), viper.Get("pass").(string))
@@ -52,10 +52,10 @@ var setDescriptionCmd = &cobra.Command{
 		}
 		defer resp.Body.Close()
 
-		if code, _ := strconv.Atoi(resp.Status); code >= 300 {
+		if resp.StatusCode >= 300 {
 			log.Fatal("There was an error updating the description. Code " + resp.Status)
 		} else {
-			fmt.Println("Successfully updated.")
+			fmt.Printf("Successfully updated with code %d.\n", resp.StatusCode)
 		}
 	},
 }


### PR DESCRIPTION
Fix missing auth env vars

- Also fix reporting errors as `strconv.Atoi(resp.Status)` is always 0.
- This will unmask an error that docker hub image description cannot be
  updated with username+token currently (see https://github.com/christian-korneck/docker-pushrm#user-content-conflict-with-dockerhub-personal-access-tokens-and-2fa-auth)

